### PR TITLE
Devel

### DIFF
--- a/pyprf_feature/analysis/__main__.py
+++ b/pyprf_feature/analysis/__main__.py
@@ -21,7 +21,7 @@ strDir = os.path.dirname(os.path.abspath(__file__))
 
 
 def main():
-    """py_pRF_mapping entry point."""
+    """pyprf_feature entry point."""
     # Get list of input arguments (without first one, which is the path to the
     # function that is called):  --NOTE: This is another way of accessing
     # input arguments, but since we use 'argparse' it is redundant.
@@ -41,30 +41,8 @@ def main():
                                  testing mode.'
                            )
 
-    # # Add argument to namespace - test flag:
-    # objParser.add_argument('-test',
-    #                        action='store_true',
-    #                        help='Whether to run a test with pytest.'
-    #                        )
-
     # Namespace object containign arguments and values:
     objNspc = objParser.parse_args()
-
-    # # Get test flag from argument parser ('True' if the '-test' flag is
-    # # provided, otherwise 'False'):
-    # lgcTest = objNspc.test
-
-    # if lgcTest:
-
-    #     print('Test mode initiated...')
-
-    #     # Path of config file for tests:
-    #     strCsvCnfg = (strDir + '/testing/config_testing.csv')
-
-    #     # Signal test mode to lower functions:
-    #     lgcTest = True
-
-    # else:
 
     # Get path of config file from argument parser:
     strCsvCnfg = objNspc.config

--- a/pyprf_feature/analysis/find_prf_cpu.py
+++ b/pyprf_feature/analysis/find_prf_cpu.py
@@ -194,6 +194,8 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
         # models are restricted to particular voxels
         if lgcRstr is not None:
             lgcVxl = lgcRstr[:, idxMdl]
+            if idxPrc == 0:
+                print('------------Number of voxels: ' + str(np.sum(lgcVxl)))
 
         # Status indicator (only used in the first of the parallel
         # processes):

--- a/pyprf_feature/analysis/find_prf_cpu.py
+++ b/pyprf_feature/analysis/find_prf_cpu.py
@@ -28,7 +28,7 @@ from pyprf_feature.analysis.find_prf_utils_cy_two import (cy_lst_sq_two,
 
 
 def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
-                 lgcXval, varNumXval, queOut, lgcPrint=True):
+                 lgcXval, varNumXval, queOut, lgcRstr=None, lgcPrint=True):
     """
     Find best fitting pRF model for voxel time course, using the CPU.
 
@@ -53,6 +53,8 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
         Number of folds for k-fold cross-validation.
     queOut : multiprocessing.queues.Queue
         Queue to put the results on.
+    lgcRstr : boolean numpy array or None, default None
+        Logical to restrict certain models to particular voxels.
     lgcPrint : boolean
         Whether print statements should be executed.
 
@@ -171,6 +173,11 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
         varCntSts01 = 0
         varCntSts02 = 0
 
+    # If user does not restrict model space for particular voxels, select
+    # all voxels
+    if lgcRstr is None:
+        lgcVxl = slice(None)
+
     # There can be pRF model time courses with a variance of zero (i.e. pRF
     # models that are not actually responsive to the stimuli). For time
     # efficiency, and in order to avoid division by zero, we ignore these
@@ -182,6 +189,11 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
 
     # Loop through pRF models:
     for idxMdl in range(0, varNumMdls):
+
+        # If desired by user, restrict the model fitting such that certain
+        # models are restricted to particular voxels
+        if lgcRstr is not None:
+            lgcVxl = lgcRstr[:, idxMdl]
 
         # Status indicator (only used in the first of the parallel
         # processes):
@@ -209,7 +221,7 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
         # that is greater than zero:
         if np.all(np.greater(aryPrfTcVar[idxMdl], varZero32), axis=0):
 
-            # get predictor time courses for this specific model
+            # Get predictor time courses for this specific model
             vecMdl = aryPrfTc[idxMdl, :, :].T
 
             # Check whether we need to crossvalidate
@@ -227,14 +239,14 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                     if varNumFtr == 1:
                         # For time course with one predictors
                         aryResXval = cy_lst_sq_xval_one(np.squeeze(vecMdl),
-                                                        aryFuncChnk,
+                                                        aryFuncChnk[:, lgcVxl],
                                                         aryIdxTrn,
                                                         aryIdxTst)
 
                     elif varNumFtr == 2:
                         # For time course with two predictors
                         aryResXval = cy_lst_sq_xval_two(vecMdl,
-                                                        aryFuncChnk,
+                                                        aryFuncChnk[:, lgcVxl],
                                                         aryIdxTrn,
                                                         aryIdxTst)
 
@@ -246,7 +258,7 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                 # Numpy version:
                 elif strVersion == 'numpy':
 
-                    aryResXval = np_lst_sq_xval(vecMdl, aryFuncChnk,
+                    aryResXval = np_lst_sq_xval(vecMdl, aryFuncChnk[:, lgcVxl],
                                                 aryIdxTrn, aryIdxTst)
 
                 # calculate the average cross validation error across
@@ -266,12 +278,12 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                     if varNumFtr == 1:
                         # For time course with one predictors
                         aryTmpBts, vecTmpRes = cy_lst_sq_one(
-                            np.squeeze(vecMdl), aryFuncChnk)
+                            np.squeeze(vecMdl), aryFuncChnk[:, lgcVxl])
 
                     elif varNumFtr == 2:
                         # For time course with two predictors
-                        aryTmpBts, vecTmpRes = cy_lst_sq_two(vecMdl,
-                                                             aryFuncChnk)
+                        aryTmpBts, vecTmpRes = \
+                            cy_lst_sq_two(vecMdl, aryFuncChnk[:, lgcVxl])
                     else:
                         if lgcPrint:
                             print('Cython currently not implemented for ' +
@@ -282,29 +294,32 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
 
                     # Numpy linalg.lstsq is used to calculate the
                     # beta values and residuals of the current model:
-                    aryTmpBts, vecTmpRes = np_lst_sq(vecMdl, aryFuncChnk)
+                    aryTmpBts, vecTmpRes = np_lst_sq(vecMdl,
+                                                     aryFuncChnk[:, lgcVxl])
 
             # Check whether current crossvalidation error (xval=True)
             # or residuals (xval=False) are lower than previously
             # calculated ones:
-            vecLgcTmpRes = np.less(vecTmpRes, vecBstRes)
+            vecLgcTmpRes = np.less(vecTmpRes, vecBstRes[lgcVxl])
 
             # Replace best x and y position values, and SD values:
-            vecBstXpos[vecLgcTmpRes] = aryMdlParams[idxMdl, 0]
-            vecBstYpos[vecLgcTmpRes] = aryMdlParams[idxMdl, 1]
-            vecBstSd[vecLgcTmpRes] = aryMdlParams[idxMdl, 2]
+            vecBstXpos[lgcVxl][vecLgcTmpRes] = aryMdlParams[idxMdl, 0]
+            vecBstYpos[lgcVxl][vecLgcTmpRes] = aryMdlParams[idxMdl, 1]
+            vecBstSd[lgcVxl][vecLgcTmpRes] = aryMdlParams[idxMdl, 2]
 
             # Replace best mean residual values:
-            vecBstRes[vecLgcTmpRes] = vecTmpRes[vecLgcTmpRes]
+            vecBstRes[lgcVxl][vecLgcTmpRes] = vecTmpRes[vecLgcTmpRes]
 
             if not lgcXval:
                 # Replace best beta values:
-                aryBstBts[vecLgcTmpRes, :] = aryTmpBts[:, vecLgcTmpRes].T
+                aryBstBts[lgcVxl, :][vecLgcTmpRes, :] = \
+                    aryTmpBts[:, vecLgcTmpRes].T
 
             # In case we cross-validate we also save and replace the best
             # residual values for every fold (not only mean across folds):
             if lgcXval:
-                aryBstResFlds[vecLgcTmpRes, :] = aryResXval[vecLgcTmpRes, :]
+                aryBstResFlds[lgcVxl, :][vecLgcTmpRes, :] = \
+                    aryResXval[vecLgcTmpRes, :]
 
         # Status indicator (only used in the first of the parallel
         # processes):
@@ -342,26 +357,26 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
         # Loop over all best-fitting model parameter combinations found
         for vecPrm in aryUnqRows:
             # Get logical for voxels for which this prm combi was the best
-            lgcVxl = np.isclose(aryBstPrm, vecPrm, atol=1e-04).all(axis=1)
+            lgcPrm = np.isclose(aryBstPrm, vecPrm, atol=1e-04).all(axis=1)
             # Get logical index for the model number
             # This can only be 1 index, so we directly get 1st entry of array
             lgcIndMdl = np.where(np.isclose(aryMdlParams, vecPrm,
                                             atol=1e-04).all(axis=1))[0][0]
 
-            if np.all(np.invert(lgcVxl)):
+            if np.all(np.invert(lgcPrm)):
                 if lgcPrint:
                     print('------------No voxel found, process ' + str(idxPrc))
             # Mark those voxels that were visited
-            vecVxlTst[lgcVxl] += 1
+            vecVxlTst[lgcPrm] += 1
 
             # Get voxel time course
-            aryVxlTc = aryFuncChnk[:, lgcVxl]
+            aryVxlTc = aryFuncChnk[:, lgcPrm]
 
             # Get model time courses
             aryMdlTc = aryPrfTc[lgcIndMdl, :, :].T
 
             # Calculate beta parameter estimates for entire model
-            aryBstBts[lgcVxl, :] = np.linalg.lstsq(aryMdlTc,
+            aryBstBts[lgcPrm, :] = np.linalg.lstsq(aryMdlTc,
                                                    aryVxlTc,
                                                    rcond=-1)[0].T
 
@@ -378,7 +393,7 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                 vecSsTot = np.sum(np.power(aryFuncDev,
                                            2.0),
                                   axis=0)
-                arySsTotXval[lgcVxl, idxXval] = vecSsTot
+                arySsTotXval[lgcPrm, idxXval] = vecSsTot
 
         # check that every voxel was visited exactly once
         errMsg = 'At least one voxel visited more than once for SStot calc'

--- a/pyprf_feature/analysis/find_prf_cpu.py
+++ b/pyprf_feature/analysis/find_prf_cpu.py
@@ -217,9 +217,12 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                 if varCntSts01 < varStsStpSze:
                     varCntSts01 = varCntSts01 + int(1)
 
-        # Only fit pRF model if all of the feauture predictos have a variance
-        # that is greater than zero:
-        if np.all(np.greater(aryPrfTcVar[idxMdl], varZero32), axis=0):
+        # Only fit pRF model if:
+        # 1) all feature predictors have a variance greater than zero AND
+        # 2) at least one voxel is being tested
+        if np.logical_and(np.all(np.greater(aryPrfTcVar[idxMdl], varZero32),
+                                 axis=0),
+                          np.any(lgcVxl)):
 
             # Get predictor time courses for this specific model
             vecMdl = aryPrfTc[idxMdl, :, :].T

--- a/pyprf_feature/analysis/find_prf_cpu.py
+++ b/pyprf_feature/analysis/find_prf_cpu.py
@@ -28,7 +28,7 @@ from pyprf_feature.analysis.find_prf_utils_cy_two import (cy_lst_sq_two,
 
 
 def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
-                 lgcXval, varNumXval, queOut):
+                 lgcXval, varNumXval, queOut, lgcPrint=True):
     """
     Find best fitting pRF model for voxel time course, using the CPU.
 
@@ -53,6 +53,8 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
         Number of folds for k-fold cross-validation.
     queOut : multiprocessing.queues.Queue
         Queue to put the results on.
+    lgcPrint : boolean
+        Whether print statements should be executed.
 
     Returns
     -------
@@ -195,8 +197,8 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                              str(vecStatPrf[varCntSts01]) +
                              ' pRF models out of ' +
                              str(varNumMdls))
-
-                print(strStsMsg)
+                if lgcPrint:
+                    print(strStsMsg)
 
                 # Only increment counter if the last value has not been
                 # reached yet:
@@ -237,8 +239,9 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                                                         aryIdxTst)
 
                     else:
-                        print('Cython currently not implemented for more ' +
-                              'two predictors.')
+                        if lgcPrint:
+                            print('Cython currently not implemented for ' +
+                                  'more than two predictors.')
 
                 # Numpy version:
                 elif strVersion == 'numpy':
@@ -270,8 +273,9 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                         aryTmpBts, vecTmpRes = cy_lst_sq_two(vecMdl,
                                                              aryFuncChnk)
                     else:
-                        print('Cython currently not implemented for more ' +
-                              'two predictors.')
+                        if lgcPrint:
+                            print('Cython currently not implemented for ' +
+                                  'more than two two predictors.')
 
                 # Numpy version:
                 elif strVersion == 'numpy':
@@ -345,7 +349,8 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
                                             atol=1e-04).all(axis=1))[0][0]
 
             if np.all(np.invert(lgcVxl)):
-                print('------------No voxel found, process ' + str(idxPrc))
+                if lgcPrint:
+                    print('------------No voxel found, process ' + str(idxPrc))
             # Mark those voxels that were visited
             vecVxlTst[lgcVxl] += 1
 
@@ -386,8 +391,10 @@ def find_prf_cpu(idxPrc, aryFuncChnk, aryPrfTc, aryMdlParams, strVersion,
         # voxels and folds
         lgcExclZeros = np.all(np.greater(arySsTotXval,  np.array([0.0])),
                               axis=1)
-        print('------------Nr of voxels: ' + str(len(lgcExclZeros)))
-        print('------------Nr of voxels avove 0: ' + str(np.sum(lgcExclZeros)))
+        if lgcPrint:
+            print('------------Nr of voxels: ' + str(len(lgcExclZeros)))
+            print('------------Nr of voxels avove 0: ' +
+                  str(np.sum(lgcExclZeros)))
 
         # Calculate R2 for every crossvalidation fold seperately
         aryBstR2fld = np.subtract(

--- a/pyprf_feature/analysis/find_prf_gpu.py
+++ b/pyprf_feature/analysis/find_prf_gpu.py
@@ -28,7 +28,7 @@ except ImportError:
 
 
 def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
-                   aryPrfTc, varL2reg, queOut):
+                   aryPrfTc, varL2reg, queOut, lgcPrint=True):
     """
     Find best pRF model for voxel time course.
 
@@ -53,6 +53,8 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
         L2 regularisation factor for ridge regression.
     queOut : multiprocessing.queues.Queue
         Queue to put the results on.
+    lgcPrint : boolean
+        Whether print statements should be executed.
 
     Returns
     -------
@@ -111,8 +113,8 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
 
     # -------------------------------------------------------------------------
     # *** Prepare pRF model time courses for graph
-
-    print('------Prepare pRF model time courses for graph')
+    if lgcPrint:
+        print('------Prepare pRF model time courses for graph')
 
     # Information about pRF model parameters:
     varNumX = np.shape(vecMdlXpos)[0]
@@ -175,10 +177,10 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
     # Size of pRF time courses in MB:
     varSzePrf = np.divide(float(aryPrfTc.nbytes),
                           1000000.0)
-
-    print(('---------Size of pRF time courses: '
-           + str(np.around(varSzePrf))
-           + ' MB'))
+    if lgcPrint:
+        print(('---------Size of pRF time courses: '
+               + str(np.around(varSzePrf))
+               + ' MB'))
 
     # Put pRF model time courses into list:
     lstPrfTc = [None] * aryPrfTc.shape[0]
@@ -191,8 +193,8 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
 
     # -------------------------------------------------------------------------
     # *** Prepare functional data for graph
-
-    print('------Prepare functional data for graph')
+    if lgcPrint:
+        print('------Prepare functional data for graph')
 
     # Number of voxels to be fitted:
     varNumVox = aryFunc.shape[0]
@@ -214,17 +216,18 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
     # Size of functional data in MB:
     varSzeFunc = np.divide(float(aryFunc.nbytes),
                            1000000.0)
-
-    print(('---------Size of functional data: '
-           + str(np.around(varSzeFunc))
-           + ' MB'))
+    if lgcPrint:
+        print(('---------Size of functional data: '
+               + str(np.around(varSzeFunc))
+               + ' MB'))
 
     # Number of chunks to create:
     varNumChnk = int(np.ceil(np.divide(varSzeFunc, varSzeMax)))
 
-    print(('---------Functional data will be split into '
-           + str(varNumChnk)
-           + ' batches'))
+    if lgcPrint:
+        print(('---------Functional data will be split into '
+               + str(varNumChnk)
+               + ' batches'))
 
     # Vector with the indicies at which the functional data will be separated
     # in order to be chunked up for the parallel processes:
@@ -313,15 +316,14 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
 
     # -------------------------------------------------------------------------
     # *** Loop through chunks
-
-    print('------Run graph')
+    if lgcPrint:
+        print('------Run graph')
 
     for idxChnk in range(varNumChnk):
-
-        print(('---------Chunk: ' + str(idxChnk)))
-
-        print('lstPrfTc[0].shape')
-        print(lstPrfTc[0].shape)
+        if lgcPrint:
+            print(('---------Chunk: ' + str(idxChnk)))
+            print('lstPrfTc[0].shape')
+            print(lstPrfTc[0].shape)
 
         # Define session:
         # objSess = tf.Session()
@@ -329,8 +331,8 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
 
             # -----------------------------------------------------------------
             # *** Prepare queue
-
-            print('------Define computational graph, queue & session')
+            if lgcPrint:
+                print('------Define computational graph, queue & session')
 
             # Queue capacity:
             varCapQ = 10
@@ -509,7 +511,8 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
                                  + str(vecStatPrc[varCntSts01])
                                  + ' % --- Number of elements on queue: '
                                  + str(varTmpSzeQ))
-                    print(strStsMsg)
+                    if lgcPrint:
+                        print(strStsMsg)
                     # Only increment counter if the last value has not been
                     # reached yet:
                     if varCntSts01 < varStsStpSze:
@@ -529,8 +532,8 @@ def funcFindPrfGpu(idxPrc, vecMdlXpos, vecMdlYpos, vecMdlSd, aryFunc,  # noqa
 
     # -------------------------------------------------------------------------
     # *** Post-process results
-
-    print('------Post-processing results')
+    if lgcPrint:
+        print('------Post-processing results')
 
     # Array for model parameters. At the moment, we have the indices of the
     # best fitting models, so we need an array that tells us what model

--- a/pyprf_feature/analysis/model_creation_main.py
+++ b/pyprf_feature/analysis/model_creation_main.py
@@ -101,20 +101,25 @@ def model_creation(dicCnfg):
                                     cfg.varExtYmax, cfg.varNumPrfSizes,
                                     cfg.varPrfStdMin, cfg.varPrfStdMax,
                                     kwUnt='pix', kwCrd=cfg.strKwCrd)
+        # *********************************************************************
 
         # *********************************************************************
         # *** Exclude model parameters whose prf center would lie outside the
         # stimulated area
-        print('------Exclude model params with prf center outside stim area')
-        varNumMdlBfr = aryMdlParams.shape[0]
-        # Get logical for model inclusion
-        lgcMdlInc = aryStimArea[aryMdlParams[:, 0].astype(np.int32),
-                                aryMdlParams[:, 1].astype(np.int32)]
-        # Exclude models with prf center outside stimulated area
-        aryMdlParams = aryMdlParams[lgcMdlInc, :]
-
-        print('---------Number of models excluded: ' +
-              str(varNumMdlBfr-aryMdlParams.shape[0]))
+#        print('------Exclude model params with prf center outside stim area')
+#        varNumMdlBfr = aryMdlParams.shape[0]
+#        # Get logical for model inclusion
+#        lgcMdlInc = aryStimArea[aryMdlParams[:, 0].astype(np.int32),
+#                                aryMdlParams[:, 1].astype(np.int32)]
+#        # Exclude models with prf center outside stimulated area
+#        aryMdlParams = aryMdlParams[lgcMdlInc, :]
+#
+#        print('---------Number of models excluded: ' +
+#              str(varNumMdlBfr-aryMdlParams.shape[0]))
+#        
+        
+        lgcMdlInc = np.ones(aryMdlParams.shape[0]).astype(np.bool)
+        # *********************************************************************
 
         # *********************************************************************
         # *** Create 2D Gauss model responses to spatial conditions.

--- a/pyprf_feature/analysis/model_creation_main.py
+++ b/pyprf_feature/analysis/model_creation_main.py
@@ -83,6 +83,13 @@ def model_creation(dicCnfg):
         print('------Load temporal condition information')
 
         aryTmpExpInf = np.load(cfg.strTmpExpInf)
+        # add fourth column to make it appropriate for pyprf_feature
+        if aryTmpExpInf.shape[-1] == 3:
+            print('---------Added fourth column')
+            vecNewCol = np.greater(aryTmpExpInf[:, 0], 0).astype(np.float16)
+            aryTmpExpInf = np.concatenate(
+                (aryTmpExpInf, np.expand_dims(vecNewCol, axis=1)), axis=1)
+
         # *********************************************************************
 
         # *********************************************************************

--- a/pyprf_feature/analysis/model_creation_main.py
+++ b/pyprf_feature/analysis/model_creation_main.py
@@ -72,9 +72,6 @@ def model_creation(dicCnfg):
         # move us up.
         arySptExpInf = np.rot90(arySptExpInf, k=3)
 
-        # Calculate the areas that were stimulated during the experiment
-        aryStimArea = np.sum(arySptExpInf, axis=-1).astype(np.bool)
-
         # *********************************************************************
 
         # *********************************************************************
@@ -101,24 +98,6 @@ def model_creation(dicCnfg):
                                     cfg.varExtYmax, cfg.varNumPrfSizes,
                                     cfg.varPrfStdMin, cfg.varPrfStdMax,
                                     kwUnt='pix', kwCrd=cfg.strKwCrd)
-        # *********************************************************************
-
-        # *********************************************************************
-        # *** Exclude model parameters whose prf center would lie outside the
-        # stimulated area
-#        print('------Exclude model params with prf center outside stim area')
-#        varNumMdlBfr = aryMdlParams.shape[0]
-#        # Get logical for model inclusion
-#        lgcMdlInc = aryStimArea[aryMdlParams[:, 0].astype(np.int32),
-#                                aryMdlParams[:, 1].astype(np.int32)]
-#        # Exclude models with prf center outside stimulated area
-#        aryMdlParams = aryMdlParams[lgcMdlInc, :]
-#
-#        print('---------Number of models excluded: ' +
-#              str(varNumMdlBfr-aryMdlParams.shape[0]))
-#        
-        
-        lgcMdlInc = np.ones(aryMdlParams.shape[0]).astype(np.bool)
         # *********************************************************************
 
         # *********************************************************************
@@ -184,4 +163,4 @@ def model_creation(dicCnfg):
 
     # *************************************************************************
 
-    return aryPrfTc, lgcMdlInc
+    return aryPrfTc

--- a/pyprf_feature/analysis/model_creation_main.py
+++ b/pyprf_feature/analysis/model_creation_main.py
@@ -65,7 +65,7 @@ def model_creation(dicCnfg):
         # arySptExpInf by 90 degrees rightward. This will insure that with the
         # 0th axis we index the scientific x-axis and higher values move us to
         # the right on that x-axis. It will also ensure that the 1st
-        # python axis indexes the scientific y-axis and higher values will 
+        # python axis indexes the scientific y-axis and higher values will
         # move us up.
         arySptExpInf = np.rot90(arySptExpInf, k=3)
 

--- a/pyprf_feature/analysis/model_creation_opt.py
+++ b/pyprf_feature/analysis/model_creation_opt.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""pRF model creation."""
+
+# Part of pyprf_feature library
+# Copyright (C) 2018  Marian Schneider, Ingo Marquardt
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+from pyprf_feature.analysis.utils_general import cls_set_config
+from pyprf_feature.analysis.model_creation_utils import (crt_mdl_rsp,
+                                                         crt_prf_ftr_tc,
+                                                         )
+
+
+def model_creation_opt(dicCnfg, aryMdlParams):
+    """
+    Create or load pRF model time courses.
+
+    Parameters
+    ----------
+    dicCnfg : dict
+        Dictionary containing config parameters.
+    aryMdlParams : numpy arrays
+        x, y and sigma parameters.
+
+    Returns
+    -------
+    aryPrfTc : np.array
+        4D numpy array with pRF time course models, with following dimensions:
+        `aryPrfTc[x-position, y-position, SD, volume]`.
+    """
+    # *************************************************************************
+    # *** Load parameters from config file
+
+    # Load config parameters from dictionary into namespace:
+    cfg = cls_set_config(dicCnfg)
+    # *************************************************************************
+
+    if cfg.lgcCrteMdl:
+
+        # *********************************************************************
+        # *** Load spatial condition information
+
+        arySptExpInf = np.load(cfg.strSptExpInf)
+
+        # Here we assume scientific convention and orientation of images where
+        # the origin should fall in the lower left corner, the x-axis occupies
+        # the width and the y-axis occupies the height dimension of the screen.
+        # We also assume that the first dimension that the user provides
+        # indexes x and the second indexes the y-axis. Since python is column
+        # major (i.e. first indexes columns, only then rows), we need to rotate
+        # arySptExpInf by 90 degrees rightward. This will insure that with the
+        # 0th axis we index the scientific x-axis and higher values move us to
+        # the right on that x-axis. It will also ensure that the 1st
+        # python axis indexes the scientific y-axis and higher values will
+        # move us up.
+        arySptExpInf = np.rot90(arySptExpInf, k=3)
+
+        # *********************************************************************
+
+        # *********************************************************************
+        # *** Load temporal condition information
+
+        # load temporal information about presented stimuli
+        aryTmpExpInf = np.load(cfg.strTmpExpInf)
+        # add fourth column to make it appropriate for pyprf_feature
+        if aryTmpExpInf.shape[-1] == 3:
+            vecNewCol = np.greater(aryTmpExpInf[:, 0], 0).astype(np.float16)
+            aryTmpExpInf = np.concatenate(
+                (aryTmpExpInf, np.expand_dims(vecNewCol, axis=1)), axis=1)
+
+        # *********************************************************************
+
+        # *********************************************************************
+        # *** Create 2D Gauss model responses to spatial conditions.
+
+        aryMdlRsp = crt_mdl_rsp(arySptExpInf, (int(cfg.varVslSpcSzeX),
+                                               int(cfg.varVslSpcSzeY)),
+                                aryMdlParams, cfg.varPar)
+        del(arySptExpInf)
+
+        # *********************************************************************
+
+        # *********************************************************************
+        # *** Create prf time course models
+
+        aryPrfTc = crt_prf_ftr_tc(aryMdlRsp, aryTmpExpInf, cfg.varNumVol,
+                                  cfg.varTr, cfg.varTmpOvsmpl,
+                                  cfg.switchHrfSet, (int(cfg.varVslSpcSzeX),
+                                                     int(cfg.varVslSpcSzeY)),
+                                  cfg.varPar)
+
+        del(aryMdlRsp)
+
+        # *********************************************************************
+
+    return aryPrfTc

--- a/pyprf_feature/analysis/model_creation_utils.py
+++ b/pyprf_feature/analysis/model_creation_utils.py
@@ -254,15 +254,15 @@ def crt_mdl_prms(tplPngSize, varNum1, varExtXmin,  varExtXmax, varNum2,
         # Vector with the angular position:
         vecTht = np.linspace(0.0, 2*np.pi, varNum2, endpoint=False)
 
-        # get all possible combinations on the grid, using matrix indexing ij
+        # Get all possible combinations on the grid, using matrix indexing ij
         # of output
         aryRad, aryTht = np.meshgrid(vecRad, vecTht, indexing='ij')
 
-        # faltten arrays to be able to combine them with meshgrid
+        # Flatten arrays to be able to combine them with meshgrid
         vecRad = aryRad.flatten()
         vecTht = aryTht.flatten()
 
-        # convert from polar to cartesian
+        # Convert from polar to cartesian
         vecX, vecY = map_pol_to_crt(vecTht, vecRad)
 
         # Vector with standard deviations pRF models (in degree of vis angle):
@@ -598,7 +598,8 @@ def crt_prf_ftr_tc(aryMdlRsp, aryTmpExpInf, varNumVol, varTr, varTmpOvsmpl,
     """
 
     # identify number of unique feautures
-    vecFeat = np.nonzero(np.unique(aryTmpExpInf[:, 3]))[0]
+    vecFeat = np.unique(aryTmpExpInf[:, 3])
+    vecFeat = vecFeat[np.nonzero(vecFeat)[0]]
 
     # preallocate the output array
     aryPrfTc = np.zeros((aryMdlRsp.shape[0], 0, varNumVol),

--- a/pyprf_feature/analysis/prepare.py
+++ b/pyprf_feature/analysis/prepare.py
@@ -120,7 +120,7 @@ def prep_models(aryPrfTc, varSdSmthTmp=2.0, lgcPrint=True):
     return aryPrfTc
 
 
-def prep_func(strPathNiiMask, lstPathNiiFunc, varAvgThr=100.,
+def prep_func(strPathNiiMask, lstPathNiiFunc, varAvgThr=-100.,
               varVarThr=0.0001):
     """
     Load & prepare functional data.
@@ -262,7 +262,7 @@ def prep_func(strPathNiiMask, lstPathNiiFunc, varAvgThr=100.,
 
     # Especially if data were recorded in different sessions, there can
     # sometimes be voxels that have close to zero signal in runs from one
-    # session but regular signalin the runs from another session. These voxels
+    # session but regular signal in the runs from another session. These voxels
     # are very few, are located at the edge of the functional and can cause
     # problems during model fitting. They are therefore excluded.
 
@@ -285,9 +285,15 @@ def prep_func(strPathNiiMask, lstPathNiiFunc, varAvgThr=100.,
     # Variance needs to be greater than threshold in every single run
     vecLgcVar = np.all(aryLgcVar, axis=1)
 
+    # Are there any nan values in the functional time series?
+    vecLgcNan = np.invert(np.any(np.isnan(aryFunc), axis=1))
+
     # combine the logical vectors for exclusion resulting from low variance and
     # low mean signal time course
     vecLgcIncl = np.logical_and(vecLgcAvg, vecLgcVar)
+
+    # combine logical vectors for mean/variance with vector for nan exclsion
+    vecLgcIncl = np.logical_and(vecLgcIncl, vecLgcNan)
 
     # Array with functional data for which conditions (mask inclusion and
     # cutoff value) are fullfilled:

--- a/pyprf_feature/analysis/prepare.py
+++ b/pyprf_feature/analysis/prepare.py
@@ -23,7 +23,7 @@ from copy import deepcopy
 from pyprf_feature.analysis.utils_general import load_nii
 
 
-def prep_models(aryPrfTc, varSdSmthTmp=2.0):
+def prep_models(aryPrfTc, varSdSmthTmp=2.0, lgcPrint=True):
     """
     Prepare pRF model time courses.
 
@@ -36,7 +36,8 @@ def prep_models(aryPrfTc, varSdSmthTmp=2.0):
         Extent of temporal smoothing that is applied to functional data and
         pRF time course models, [SD of Gaussian kernel, in seconds]. If `zero`,
         no temporal smoothing is applied.
-
+    lgcPrint : boolean
+        Whether print statements should be executed.
 
     Returns
     -------
@@ -44,10 +45,11 @@ def prep_models(aryPrfTc, varSdSmthTmp=2.0):
         4D numpy array with prepared pRF time course models, same
         dimensions as input (`aryPrfTc[x-position, y-position, SD, volume]`).
     """
-    print('------Prepare pRF time course models')
+    if lgcPrint:
+        print('------Prepare pRF time course models')
 
     # Define temporal smoothing of pRF time course models
-    def funcSmthTmp(aryPrfTc, varSdSmthTmp):
+    def funcSmthTmp(aryPrfTc, varSdSmthTmp, lgcPrint=True):
         """Apply temporal smoothing to fMRI data & pRF time course models.
 
         Parameters
@@ -59,6 +61,8 @@ def prep_models(aryPrfTc, varSdSmthTmp=2.0):
             Extent of temporal smoothing that is applied to functional data and
             pRF time course models, [SD of Gaussian kernel, in seconds]. If
             `zero`, no temporal smoothing is applied.
+        lgcPrint : boolean
+            Whether print statements should be executed.
 
         Returns
         -------
@@ -94,12 +98,14 @@ def prep_models(aryPrfTc, varSdSmthTmp=2.0):
 
     # Perform temporal smoothing of pRF time course models
     if 0.0 < varSdSmthTmp:
-        print('---------Temporal smoothing on pRF time course models')
-        print('------------SD tmp smooth is: ' + str(varSdSmthTmp))
+        if lgcPrint:
+            print('---------Temporal smoothing on pRF time course models')
+            print('------------SD tmp smooth is: ' + str(varSdSmthTmp))
         aryPrfTc = funcSmthTmp(aryPrfTc, varSdSmthTmp)
 
     # Z-score the prf time course models
-    print('---------Zscore the pRF time course models')
+    if lgcPrint:
+        print('---------Zscore the pRF time course models')
     # De-mean the prf time course models:
     aryPrfTc = np.subtract(aryPrfTc, np.mean(aryPrfTc, axis=-1)[..., None])
 

--- a/pyprf_feature/analysis/pyprf_main.py
+++ b/pyprf_feature/analysis/pyprf_main.py
@@ -29,7 +29,7 @@ from pyprf_feature.analysis.model_creation_utils import crt_mdl_prms
 from pyprf_feature.analysis.prepare import prep_models, prep_func
 
 ###### DEBUGGING ###############
-#strCsvCnfg = "/home/marian/Documents/Git/pyprf_feature/pyprf_feature/analysis/config_custom.csv"
+#strCsvCnfg = "/home/marian/Documents/Testing/pyprf_feature_devel/S02_config_motDepPrf_flck_smooth_inw.csv"
 #lgcTest = False
 ################################
 
@@ -77,7 +77,7 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
     # Create model time courses. Also return logical for inclusion of model
     # parameters which will be needed later when we create model parameters
     # in degree.
-    aryPrfTc, lgcMdlInc = model_creation(dicCnfg)
+    aryPrfTc = model_creation(dicCnfg)
 
     # Deduce the number of features from the pRF time course models array
     cfg.varNumFtr = aryPrfTc.shape[1]
@@ -159,8 +159,6 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
                                 cfg.varNumPrfSizes, cfg.varPrfStdMin,
                                 cfg.varPrfStdMax, kwUnt='deg',
                                 kwCrd=cfg.strKwCrd)
-    # Restrict model parameters to pRF with center on stimualted area
-    aryMdlParams = aryMdlParams[lgcMdlInc, :]
 
     # Empty list for results (parameters of best fitting pRF model):
     lstPrfRes = [None] * cfg.varPar
@@ -175,6 +173,10 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
     lstFunc = np.array_split(aryFunc, cfg.varPar)
     # We don't need the original array with the functional data anymore:
     del(aryFunc)
+
+    # Prepare dictionary to pass as kwargs to find_prf_cpu
+    dctKw = {'lgcRstr': None,
+             'lgcPrint': True}
 
     # CPU version (using numpy or cython for pRF finding):
     if ((cfg.strVersion == 'numpy') or (cfg.strVersion == 'cython')):
@@ -193,7 +195,8 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
                                                cfg.strVersion,
                                                cfg.lgcXval,
                                                cfg.varNumXval,
-                                               queOut)
+                                               queOut),
+                                         kwargs=dctKw,
                                          )
             # Daemon (kills processes when exiting):
             lstPrcs[idxPrc].Daemon = True
@@ -210,7 +213,8 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
                                                aryMdlParams,
                                                lstFunc[idxPrc],
                                                aryPrfTc,
-                                               queOut)
+                                               queOut),
+                                         kwargs=dctKw,
                                          )
             # Daemon (kills processes when exiting):
             lstPrcs[idxPrc].Daemon = True

--- a/pyprf_feature/analysis/pyprf_main.py
+++ b/pyprf_feature/analysis/pyprf_main.py
@@ -86,7 +86,9 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
 
     # The model time courses will be preprocessed such that they are smoothed
     # (temporally) with same factor as the data and that they will be z-scored:
-    aryPrfTc = prep_models(aryPrfTc, varSdSmthTmp=cfg.varSdSmthTmp)
+    # Also return logical for inclusion of model parameters which will be
+    # needed later when we create model parameters in degree.
+    aryPrfTc, lgcMdlInc = prep_models(aryPrfTc, varSdSmthTmp=cfg.varSdSmthTmp)
 
     # The functional data will be masked and demeaned:
     aryLgcMsk, aryLgcVar, hdrMsk, aryAff, aryFunc, tplNiiShp = prep_func(
@@ -155,6 +157,8 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
                                 cfg.varNumPrfSizes, cfg.varPrfStdMin,
                                 cfg.varPrfStdMax, kwUnt='deg',
                                 kwCrd=cfg.strKwCrd)
+    # Restrict model parameters to pRF with center on stimualted area
+    aryMdlParams = aryMdlParams[lgcMdlInc, :]
 
     # Empty list for results (parameters of best fitting pRF model):
     lstPrfRes = [None] * cfg.varPar

--- a/pyprf_feature/analysis/pyprf_main.py
+++ b/pyprf_feature/analysis/pyprf_main.py
@@ -92,6 +92,10 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
     aryLgcMsk, aryLgcVar, hdrMsk, aryAff, aryFunc, tplNiiShp = prep_func(
         cfg.strPathNiiMask, cfg.lstPathNiiFunc)
 
+    # set the precision of the header to np.float32 so that the prf results
+    # will be saved in this precision later
+    hdrMsk.set_data_dtype(np.float32)
+
     # *************************************************************************
     # *** Checks
 

--- a/pyprf_feature/analysis/pyprf_main.py
+++ b/pyprf_feature/analysis/pyprf_main.py
@@ -19,7 +19,6 @@
 
 import time
 import numpy as np
-import nibabel as nb
 import multiprocessing as mp
 
 from pyprf_feature.analysis.load_config import load_config

--- a/pyprf_feature/analysis/pyprf_main.py
+++ b/pyprf_feature/analysis/pyprf_main.py
@@ -74,7 +74,10 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
     # *************************************************************************
     # *** Create or load pRF time course models
 
-    aryPrfTc = model_creation(dicCnfg)
+    # Create model time courses. Also return logical for inclusion of model
+    # parameters which will be needed later when we create model parameters
+    # in degree.
+    aryPrfTc, lgcMdlInc = model_creation(dicCnfg)
 
     # Deduce the number of features from the pRF time course models array
     cfg.varNumFtr = aryPrfTc.shape[1]
@@ -86,9 +89,7 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
 
     # The model time courses will be preprocessed such that they are smoothed
     # (temporally) with same factor as the data and that they will be z-scored:
-    # Also return logical for inclusion of model parameters which will be
-    # needed later when we create model parameters in degree.
-    aryPrfTc, lgcMdlInc = prep_models(aryPrfTc, varSdSmthTmp=cfg.varSdSmthTmp)
+    aryPrfTc = prep_models(aryPrfTc, varSdSmthTmp=cfg.varSdSmthTmp)
 
     # The functional data will be masked and demeaned:
     aryLgcMsk, aryLgcVar, hdrMsk, aryAff, aryFunc, tplNiiShp = prep_func(
@@ -97,6 +98,7 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
     # set the precision of the header to np.float32 so that the prf results
     # will be saved in this precision later
     hdrMsk.set_data_dtype(np.float32)
+    # *************************************************************************
 
     # *************************************************************************
     # *** Checks
@@ -124,7 +126,7 @@ def pyprf(strCsvCnfg, lgcTest=False):  #noqa
             'Set strVersion equal \'numpy\'.'
         assert cfg.varNumFtr in [1, 2], strErrMsg
 
-    # check whether we need to crossvalidate
+    # Check whether we need to crossvalidate
     if np.greater(cfg.varNumXval, 1):
         cfg.lgcXval = True
     elif np.equal(cfg.varNumXval, 1):

--- a/pyprf_feature/analysis/pyprf_opt_brute.py
+++ b/pyprf_feature/analysis/pyprf_opt_brute.py
@@ -1,0 +1,437 @@
+# -*- coding: utf-8 -*-
+"""Optimize given pRF paramaters using brute-force grid search."""
+
+# Part of pyprf_feature library
+# Copyright (C) 2018  Marian Schneider, Ingo Marquardt
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+import numpy as np
+import multiprocessing as mp
+
+from pyprf_feature.analysis.load_config import load_config
+from pyprf_feature.analysis.utils_general import (cls_set_config, load_res_prm,
+                                                  export_nii, joinRes,
+                                                  map_pol_to_crt)
+from pyprf_feature.analysis.model_creation_opt import model_creation_opt
+from pyprf_feature.analysis.model_creation_utils import rmp_deg_pixel_xys
+from pyprf_feature.analysis.prepare import prep_models, prep_func
+
+
+###### DEBUGGING ###############
+#strCsvCnfg = "/media/sf_D_DRIVE/MotDepPrf/Analysis/S07/04_motDepPrf/pRF_results/S07_config_motDepPrf_flck_smooth.csv"
+#lgcTest = False
+################################
+
+def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
+    """
+    Function for optimizing given pRF paramaters using brute-force grid search.
+
+    Parameters
+    ----------
+    strCsvCnfg : str
+        Absolute file path of config file.
+    objNspc : object
+        Name space from command line arguments.
+    lgcTest : Boolean
+        Whether this is a test (pytest). If yes, absolute path of pyprf libary
+        will be prepended to config file paths.
+    """
+    # *************************************************************************
+    # *** Check time
+    print('---pRF analysis')
+    varTme01 = time.time()
+    # *************************************************************************
+
+    # *************************************************************************
+    # *** Preparations
+
+    # Load config parameters from csv file into dictionary:
+    dicCnfg = load_config(strCsvCnfg, lgcTest=lgcTest)
+
+    # Load config parameters from dictionary into namespace:
+    cfg = cls_set_config(dicCnfg)
+
+    # Conditional imports:
+    if cfg.strVersion == 'gpu':
+        from pyprf_feature.analysis.find_prf_gpu import find_prf_gpu
+    if ((cfg.strVersion == 'cython') or (cfg.strVersion == 'numpy')):
+        from pyprf_feature.analysis.find_prf_cpu import find_prf_cpu
+
+    # Convert preprocessing parameters (for temporal smoothing)
+    # from SI units (i.e. [s]) into units of data array (volumes):
+    cfg.varSdSmthTmp = np.divide(cfg.varSdSmthTmp, cfg.varTr)
+    # *************************************************************************
+
+    # *************************************************************************
+    # *** Preprocessing
+
+    # The functional data will be masked and demeaned:
+    aryLgcMsk, aryLgcVar, hdrMsk, aryAff, aryFunc, tplNiiShp = prep_func(
+        cfg.strPathNiiMask, cfg.lstPathNiiFunc)
+
+    # *************************************************************************
+    # *** Checks
+
+    # Make sure that if gpu fitting is used, the number of cross-validations is
+    # set to 1, not higher
+    if cfg.strVersion == 'gpu':
+        strErrMsg = 'Stopping program. ' + \
+            'Cross-validation on GPU is currently not supported. ' + \
+            'Set varNumXval equal to 1 in csv file in order to continue. '
+        assert cfg.varNumXval == 1, strErrMsg
+
+    # For the GPU version, we need to set down the parallelisation to 1 now,
+    # because no separate CPU threads are to be created. We may still use CPU
+    # parallelisation for preprocessing, which is why the parallelisation
+    # factor is only reduced now, not earlier.
+    if cfg.strVersion == 'gpu':
+        cfg.varPar = 1
+
+#    # Make sure that if cython is used, the number of features is 1 or 2,
+#    # not higher
+#    if cfg.strVersion == 'cython':
+#        strErrMsg = 'Stopping program. ' + \
+#            'Cython is not supported for more features than 1. ' + \
+#            'Set strVersion equal \'numpy\'.'
+#        assert cfg.varNumFtr in [1, 2], strErrMsg
+
+    # check whether we need to crossvalidate
+    if np.greater(cfg.varNumXval, 1):
+        cfg.lgcXval = True
+    elif np.equal(cfg.varNumXval, 1):
+        cfg.lgcXval = False
+    strErrMsg = 'Stopping program. ' + \
+        'Set numXval (number of crossvalidation folds) to 1 or higher'
+    assert np.greater_equal(cfg.varNumXval, 1), strErrMsg
+    # *************************************************************************
+
+    # *************************************************************************
+    # Load previous pRF fitting results
+    print('---String to prior results provided by user:')
+    print(objNspc.strPthPrior)
+
+    # Load the x, y, sigma winner parameters from pyprf_feature
+    lstWnrPrm = [objNspc.strPthPrior + '_x_pos.nii',
+                 objNspc.strPthPrior + '_y_pos.nii',
+                 objNspc.strPthPrior + '_SD.nii']
+    lstPrmInt, objHdr, aryAff = load_res_prm(lstWnrPrm,
+                                             lstFlsMsk=[cfg.strPathNiiMask])
+    # Convert list to array
+    assert len(lstPrmInt) == 1
+    aryIntGssPrm = lstPrmInt[0]
+    del(lstPrmInt)
+
+    # Some voxels were excluded because they did not have sufficient mean
+    # and/or variance - exclude their nitial parameters, too
+    aryIntGssPrm = aryIntGssPrm[aryLgcVar, :]
+
+    # *************************************************************************
+
+    # *************************************************************************
+    # *** Sort voxels by polar angle/previous parameters
+
+    # Calculate polar angles
+    aryPlrAng = np.arctan2(aryIntGssPrm[:, 1], aryIntGssPrm[:, 0])
+
+    # Get an array of unique polar angles
+    aryUnqPlrAng, aryUnqPlrAngInd = np.unique(aryPlrAng, return_inverse=True)
+
+    # Get logical arrays that index voxels with particular polar angle
+    lstLgcUnqPlrAng = []
+    for indPlrAng in range(len(aryUnqPlrAng)):
+        lstLgcUnqPlrAng.append([aryUnqPlrAngInd == indPlrAng][0])
+
+    print('---Number of (radial position) options provided by user: ' +
+          str(objNspc.varNumOpt))
+    print('---Number of unique polar angles found in prior results: ' +
+          str(len(aryUnqPlrAng)))
+
+    # *************************************************************************
+    # *** Perform prf fitting
+
+    # Create array for collecting winner parameters
+    aryBstXpos = np.zeros((aryPlrAng.shape[0]))
+    aryBstYpos = np.zeros((aryPlrAng.shape[0]))
+    aryBstSd = np.zeros((aryPlrAng.shape[0]))
+    aryBstR2 = np.zeros((aryPlrAng.shape[0]))
+    aryBstBts = np.zeros((aryPlrAng.shape[0], 1))
+    if np.greater(cfg.varNumXval, 1):
+        aryBstR2Single = np.zeros((aryPlrAng.shape[0],
+                                   len(cfg.lstPathNiiFunc)))
+
+    # loop over all found instances of polar angle/previous parameters
+    for indPlrAng in range(len(aryUnqPlrAng)):
+
+        print('------Polar angle number ' + str(indPlrAng) + ' out of ' +
+              str(len(aryUnqPlrAng)))
+
+        # get the polar angle for the current voxel batch
+        varPlrAng = np.array(aryUnqPlrAng[indPlrAng])
+
+        # get logical array to index voxels with this particular polar angle
+        lgcUnqPlrAng = lstLgcUnqPlrAng[indPlrAng]
+
+        print('------Number of voxels: ' + str(np.sum(lgcUnqPlrAng)))
+
+        # Create list with chunks of functional data for parallel processes:
+        lstFunc = np.array_split(aryFunc[lgcUnqPlrAng, :], cfg.varPar)
+
+        # *********************************************************************
+
+        # *********************************************************************
+        # *** Create time course models for this particular polar angle
+
+        # Vector with the radial position:
+        vecRad = np.linspace(0.0, cfg.varExtXmax, objNspc.varNumOpt,
+                             endpoint=True)
+
+        # Get all possible combinations on the grid, using matrix indexing ij
+        # of output
+        aryRad, aryTht = np.meshgrid(vecRad, varPlrAng, indexing='ij')
+
+        # Flatten arrays to be able to combine them with meshgrid
+        vecRad = aryRad.flatten()
+        vecTht = aryTht.flatten()
+
+        # Convert from polar to cartesian
+        vecX, vecY = map_pol_to_crt(vecTht, vecRad)
+
+        # Vector with standard deviations pRF models (in degree of vis angle):
+        vecPrfSd = np.linspace(cfg.varPrfStdMin, cfg.varPrfStdMax,
+                               cfg.varNumPrfSizes, endpoint=True)
+
+        # Create model parameters
+        varNumMdls = len(vecX) * len(vecPrfSd)
+        aryMdlParams = np.zeros((varNumMdls, 3), dtype=np.float32)
+
+        varCntMdlPrms = 0
+
+        # Loop through x-positions:
+        for idxXY in range(0, len(vecX)):
+
+            # Loop through standard deviations (of Gaussian pRF models):
+            for idxSd in range(0, len(vecPrfSd)):
+
+                # Place index and parameters in array:
+                aryMdlParams[varCntMdlPrms, 0] = vecX[idxXY]
+                aryMdlParams[varCntMdlPrms, 1] = vecY[idxXY]
+                aryMdlParams[varCntMdlPrms, 2] = vecPrfSd[idxSd]
+
+                # Increment parameter index:
+                varCntMdlPrms += 1
+
+        # Convert winner parameters from degrees of visual angle to pixel
+        vecIntX, vecIntY, vecIntSd = rmp_deg_pixel_xys(aryMdlParams[:, 0],
+                                                       aryMdlParams[:, 1],
+                                                       aryMdlParams[:, 2],
+                                                       cfg.tplVslSpcSze,
+                                                       cfg.varExtXmin,
+                                                       cfg.varExtXmax,
+                                                       cfg.varExtYmin,
+                                                       cfg.varExtYmax)
+
+        aryMdlParamsPxl = np.column_stack((vecIntX, vecIntY, vecIntSd))
+
+        # Create model time courses
+        aryPrfTc = model_creation_opt(dicCnfg, aryMdlParamsPxl)
+
+        # The model time courses will be preprocessed such that they are
+        # smoothed (temporally) with same factor as the data and that they will
+        # be z-scored:
+        aryPrfTc = prep_models(aryPrfTc, varSdSmthTmp=cfg.varSdSmthTmp)
+
+        # *********************************************************************
+
+        # *********************************************************************
+        # *** Find best model for voxels with this particular polar angle
+
+        # Empty list for results (parameters of best fitting pRF model):
+        lstPrfRes = [None] * cfg.varPar
+
+        # Empty list for processes:
+        lstPrcs = [None] * cfg.varPar
+
+        # Create a queue to put the results in:
+        queOut = mp.Queue()
+
+        dctKw = {'lgcPrint': False}
+
+        # CPU version (using numpy or cython for pRF finding):
+        if ((cfg.strVersion == 'numpy') or (cfg.strVersion == 'cython')):
+
+            # Create processes:
+            for idxPrc in range(0, cfg.varPar):
+                lstPrcs[idxPrc] = mp.Process(target=find_prf_cpu,
+                                             args=(idxPrc,
+                                                   lstFunc[idxPrc],
+                                                   aryPrfTc,
+                                                   aryMdlParams,
+                                                   cfg.strVersion,
+                                                   cfg.lgcXval,
+                                                   cfg.varNumXval,
+                                                   queOut),
+                                             kwargs=dctKw,
+                                             )
+                # Daemon (kills processes when exiting):
+                lstPrcs[idxPrc].Daemon = True
+
+        # GPU version (using tensorflow for pRF finding):
+        elif cfg.strVersion == 'gpu':
+
+            # Create processes:
+            for idxPrc in range(0, cfg.varPar):
+                lstPrcs[idxPrc] = mp.Process(target=find_prf_gpu,
+                                             args=(idxPrc,
+                                                   aryMdlParams,
+                                                   lstFunc[idxPrc],
+                                                   aryPrfTc,
+                                                   queOut),
+                                             kwargs=dctKw,
+                                             )
+                # Daemon (kills processes when exiting):
+                lstPrcs[idxPrc].Daemon = True
+
+        # Start processes:
+        for idxPrc in range(0, cfg.varPar):
+            lstPrcs[idxPrc].start()
+
+        # Delete reference to list with function data (the data continues to
+        # exists in child process):
+        del(lstFunc)
+
+        # Collect results from queue:
+        for idxPrc in range(0, cfg.varPar):
+            lstPrfRes[idxPrc] = queOut.get(True)
+
+        # Join processes:
+        for idxPrc in range(0, cfg.varPar):
+            lstPrcs[idxPrc].join()
+
+        # *********************************************************************
+
+        # *********************************************************************
+        # *** Prepare pRF finding results for export
+
+        # Put output into correct order:
+        lstPrfRes = sorted(lstPrfRes)
+
+        # collect results from parallelization
+        aryBstTmpXpos = joinRes(lstPrfRes, cfg.varPar, 1, inFormat='1D')
+        aryBstTmpYpos = joinRes(lstPrfRes, cfg.varPar, 2, inFormat='1D')
+        aryBstTmpSd = joinRes(lstPrfRes, cfg.varPar, 3, inFormat='1D')
+        aryBstTmpR2 = joinRes(lstPrfRes, cfg.varPar, 4, inFormat='1D')
+        aryBstTmpBts = joinRes(lstPrfRes, cfg.varPar, 5, inFormat='2D')
+        if np.greater(cfg.varNumXval, 1):
+            aryTmpBstR2Single = joinRes(lstPrfRes, cfg.varPar, 6,
+                                        inFormat='2D')
+        # Delete unneeded large objects:
+        del(lstPrfRes)
+
+        # *********************************************************************
+
+        # *********************************************************************
+        # Put findings for voxels with specific polar angle into ary with
+        # result for all voxels
+        aryBstXpos[lgcUnqPlrAng] = aryBstTmpXpos
+        aryBstYpos[lgcUnqPlrAng] = aryBstTmpYpos
+        aryBstSd[lgcUnqPlrAng] = aryBstTmpSd
+        aryBstR2[lgcUnqPlrAng] = aryBstTmpR2
+        aryBstBts[lgcUnqPlrAng, :] = aryBstTmpBts
+        if np.greater(cfg.varNumXval, 1):
+            aryBstR2Single[lgcUnqPlrAng, :] = aryTmpBstR2Single
+
+    # *************************************************************************
+
+    # *************************************************************************
+    # Calculate polar angle map:
+    aryPlrAng = np.arctan2(aryBstYpos, aryBstXpos)
+    # Calculate eccentricity map (r = sqrt( x^2 + y^2 ) ):
+    aryEcc = np.sqrt(np.add(np.square(aryBstXpos),
+                            np.square(aryBstYpos)))
+    # *************************************************************************
+
+    # *************************************************************************
+    # Export each map of best parameters as a 3D nii file
+
+    print('---------Exporting results')
+
+    # Xoncatenate all the best voxel maps
+    aryBstMaps = np.stack([aryBstXpos, aryBstYpos, aryBstSd, aryBstR2,
+                           aryPlrAng, aryEcc], axis=1)
+
+    # List with name suffices of output images:
+    lstNiiNames = ['_x_pos_opt',
+                   '_y_pos_opt',
+                   '_SD_opt',
+                   '_R2_opt',
+                   '_polar_angle_opt',
+                   '_eccentricity_opt']
+
+    # Create full path names from nii file names and output path
+    lstNiiNames = [cfg.strPathOut + strNii + '.nii.gz' for strNii in
+                   lstNiiNames]
+
+    # export map results as seperate 3D nii files
+    export_nii(aryBstMaps, lstNiiNames, aryLgcMsk, aryLgcVar, tplNiiShp,
+               aryAff, hdrMsk, outFormat='3D')
+
+    # *************************************************************************
+
+    # *************************************************************************
+    # Save beta parameter estimates for every feature:
+
+    # List with name suffices of output images:
+    lstNiiNames = ['_Betas_opt']
+
+    # Create full path names from nii file names and output path
+    lstNiiNames = [cfg.strPathOut + strNii + '.nii.gz' for strNii in
+                   lstNiiNames]
+
+    # export beta parameter as a single 4D nii file
+    export_nii(aryBstBts, lstNiiNames, aryLgcMsk, aryLgcVar, tplNiiShp,
+               aryAff, hdrMsk, outFormat='4D')
+
+    # *************************************************************************
+
+    # *************************************************************************
+    # Save R2 maps from crossvalidation (saved for every run) as nii:
+
+    if np.greater(cfg.varNumXval, 1):
+
+        # truncate extremely negative R2 values
+        aryBstR2Single[np.where(np.less_equal(aryBstR2Single, -1.0))] = -1.0
+
+        # List with name suffices of output images:
+        lstNiiNames = ['_R2_single_opt']
+
+        # Create full path names from nii file names and output path
+        lstNiiNames = [cfg.strPathOut + strNii + '.nii.gz' for strNii in
+                       lstNiiNames]
+
+        # export R2 maps as a single 4D nii file
+        export_nii(aryBstR2Single, lstNiiNames, aryLgcMsk, aryLgcVar,
+                   tplNiiShp, aryAff, hdrMsk, outFormat='4D')
+
+    # *************************************************************************
+
+    # *************************************************************************
+    # *** Report time
+
+    varTme02 = time.time()
+    varTme03 = varTme02 - varTme01
+    print('---Elapsed time: ' + str(varTme03) + ' s')
+    print('---Done.')
+    # *************************************************************************

--- a/pyprf_feature/analysis/pyprf_opt_brute.py
+++ b/pyprf_feature/analysis/pyprf_opt_brute.py
@@ -364,7 +364,8 @@ def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
                                                    lstFunc[idxPrc],
                                                    aryPrfTc,
                                                    queOut),
-                                             kwargs=dctKw,
+                                             kwargs={'lgcRstr': lstRst[idxPrc],
+                                                     'lgcPrint': False},
                                              )
                 # Daemon (kills processes when exiting):
                 lstPrcs[idxPrc].Daemon = True

--- a/pyprf_feature/analysis/pyprf_opt_brute.py
+++ b/pyprf_feature/analysis/pyprf_opt_brute.py
@@ -389,6 +389,14 @@ def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
     # Calculate eccentricity map (r = sqrt( x^2 + y^2 ) ):
     aryEcc = np.sqrt(np.add(np.square(aryBstXpos),
                             np.square(aryBstYpos)))
+    # It is possible that after optimization the pRF has moved to location 0, 0
+    # In this cases, the polar angle parameter is arbitrary and will be
+    # assigned either 0 or pi. To preserve smoothness of the map, assign the
+    # initial polar angle value from independent localiser
+    lgcMvdOrgn = np.logical_and(aryBstXpos == 0.0, aryBstYpos == 0.0)
+    aryIntPlrAng = np.arctan2(aryIntGssPrm[:, 1], aryIntGssPrm[:, 0])
+    aryPlrAng[lgcMvdOrgn] = np.copy(aryIntPlrAng[lgcMvdOrgn])
+
     # *************************************************************************
 
     # *************************************************************************

--- a/pyprf_feature/analysis/pyprf_opt_brute.py
+++ b/pyprf_feature/analysis/pyprf_opt_brute.py
@@ -146,6 +146,9 @@ def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
     # Calculate polar angles
     aryPlrAng = np.arctan2(aryIntGssPrm[:, 1], aryIntGssPrm[:, 0])
 
+    # round off polar angle, so there are less unique models
+    aryPlrAng = np.round(aryPlrAng, decimals=2)
+
     # Get an array of unique polar angles
     aryUnqPlrAng, aryUnqPlrAngInd = np.unique(aryPlrAng, return_inverse=True)
 

--- a/pyprf_feature/analysis/pyprf_opt_brute.py
+++ b/pyprf_feature/analysis/pyprf_opt_brute.py
@@ -272,6 +272,18 @@ def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
 
         aryMdlParamsPxl = np.column_stack((vecIntX, vecIntY, vecIntSd))
 
+        # Calculate the areas that were stimulated during the experiment
+        arySptExpInf = np.load(cfg.strSptExpInf)
+        arySptExpInf = np.rot90(arySptExpInf, k=3)
+        aryStimArea = np.sum(arySptExpInf, axis=-1).astype(np.bool)
+
+        # Get logical to exclude models with pRF centre outside stim area
+        lgcMdlInc = aryStimArea[aryMdlParamsPxl[:, 0].astype(np.int32),
+                                aryMdlParamsPxl[:, 1].astype(np.int32)]
+        # Exclude models with prf center outside stimulated area
+        aryMdlParams = aryMdlParams[lgcMdlInc, :]
+        aryMdlParamsPxl = aryMdlParamsPxl[lgcMdlInc, :]
+
         # Create model time courses
         aryPrfTc = model_creation_opt(dicCnfg, aryMdlParamsPxl)
 

--- a/pyprf_feature/analysis/pyprf_opt_brute.py
+++ b/pyprf_feature/analysis/pyprf_opt_brute.py
@@ -38,7 +38,7 @@ from pyprf_feature.analysis.prepare import prep_models, prep_func
 #objNspc = Object()
 #objNspc.strPthPrior = "/media/sf_D_DRIVE/MotDepPrf/Analysis/S02/03_motLoc/pRF_results/pRF_results_tmpSmth"
 #objNspc.varNumOpt1 = 90
-#objNspc.varNumOpt1 = 64
+#objNspc.varNumOpt2 = 64
 #lgcTest = False
 ################################
 
@@ -88,6 +88,13 @@ def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
     # The functional data will be masked and demeaned:
     aryLgcMsk, aryLgcVar, hdrMsk, aryAff, aryFunc, tplNiiShp = prep_func(
         cfg.strPathNiiMask, cfg.lstPathNiiFunc)
+
+    # set the precision of the header to np.float32 so that the prf results
+    # will be saved in this precision later
+    hdrMsk.set_data_dtype(np.float32)
+
+    print('---Number of voxels included in analysis: ' +
+          str(np.sum(aryLgcVar)))
 
     # *************************************************************************
     # *** Checks
@@ -160,6 +167,12 @@ def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
 
     # Make sure that the maximum distance between grid points of polar angles
     assert np.max(aryDstPlrAng) < np.divide(2*np.pi, objNspc.varNumOpt2)
+
+    # Update unique polar angles such that it contains only the ones which
+    # were found in data
+    aryUnqPlrAng = aryUnqPlrAng[np.unique(aryUnqPlrAngInd)]
+    # Update indices
+    aryUnqPlrAngInd, aryDstPlrAng = find_near_pol_ang(aryPlrAng, aryUnqPlrAng)
 
     # Get logical arrays that index voxels with particular polar angle
     lstLgcUnqPlrAng = []

--- a/pyprf_feature/analysis/pyprf_opt_brute.py
+++ b/pyprf_feature/analysis/pyprf_opt_brute.py
@@ -146,6 +146,19 @@ def pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest=False):  #noqa
     # Calculate polar angles
     aryPlrAng = np.arctan2(aryIntGssPrm[:, 1], aryIntGssPrm[:, 0])
 
+    def find_near_pol_angle(aryEmpPlrAng, aryExpPlrAng):
+        """Return index of nearest expected polar angle."""
+
+        # Expected polar angle values are range from 0 to 2*pi, while
+        # The calculated angle values will range from -pi to pi
+        # Thus, bring empirical values from range -pi, pi to range 0, 2pi
+        aryEmpPlrAng = (aryEmpPlrAng + 2 * np.pi) % (2 * np.pi)
+
+        dist = np.abs(np.subtract(aryEmpPlrAng[:, None],
+                                  aryExpPlrAng[None, :]))
+
+        return np.argmin(dist, axis=-1), np.min(dist, axis=-1)
+
     # round off polar angle, so there are less unique models
     aryPlrAng = np.round(aryPlrAng, decimals=2)
 

--- a/pyprf_feature/analysis/pyprf_opt_ep.py
+++ b/pyprf_feature/analysis/pyprf_opt_ep.py
@@ -44,6 +44,18 @@ def get_arg_parse():
                            help='Number of angular positions.'
                            )
 
+    # Add argument to namespace - varNumOpt3 flag:
+    objParser.add_argument('-varNumOpt3', required=True, type=float,
+                           metavar='N3',
+                           help='Max displacement in radial direction.'
+                           )
+
+    # Add argument to namespace - varNumOpt3 flag:
+    objParser.add_argument('-lgcRstrCentre', required=False, type=bool,
+                           metavar='lgcRstrCentre', default=True,
+                           help='Restrict models to stimaluted area.'
+                           )
+
     # Namespace object containign arguments and values:
     objNspc = objParser.parse_args()
 

--- a/pyprf_feature/analysis/pyprf_opt_ep.py
+++ b/pyprf_feature/analysis/pyprf_opt_ep.py
@@ -13,7 +13,7 @@ strDir = os.path.dirname(os.path.abspath(__file__))
 
 
 def get_arg_parse():
-    """"Parses the Command Line Arguments using argparse."""
+    """Parses the Command Line Arguments using argparse."""
     # Create parser object:
     objParser = argparse.ArgumentParser()
 

--- a/pyprf_feature/analysis/pyprf_opt_ep.py
+++ b/pyprf_feature/analysis/pyprf_opt_ep.py
@@ -32,10 +32,16 @@ def get_arg_parse():
                                  Ignored if in testing mode.'
                            )
 
-    # Add argument to namespace - varNumOpt flag:
-    objParser.add_argument('-varNumOpt', type=int,
+    # Add argument to namespace - varNumOpt1 flag:
+    objParser.add_argument('-varNumOpt1', type=int,
                            metavar='N', required=True,
                            help='Number of radial positions.'
+                           )
+
+    # Add argument to namespace - varNumOpt2 flag:
+    objParser.add_argument('-varNumOpt2', type=int,
+                           metavar='N', required=True,
+                           help='Number of angular positions.'
                            )
 
     # Namespace object containign arguments and values:
@@ -56,15 +62,11 @@ def main():
 
     objNspc = get_arg_parse()
 
-    # Get path of config file from argument parser:
-    strCsvCnfg = objNspc.config
-    strPthPrior = objNspc.strPthPrior
-    varNumOpt = objNspc.varNumOpt
-
     # Print info if no config argument is provided.
-    if any(item is None for item in [strCsvCnfg, strPthPrior, varNumOpt]):
+    if any(item is None for item in [objNspc.config, objNspc.strPthPrior,
+                                     objNspc.varNumOpt1, objNspc.varNumOpt2]):
         print('Please provide the necessary input arguments, i.e.:')
-        print('   -strCsvCnfg -strPthPrior and -varNumOpt')
+        print('-strCsvCnfg -strPthPrior -varNumOpt1 and -varNumOpt2')
 
     else:
 
@@ -72,7 +74,7 @@ def main():
         lgcTest = False
 
         # Call to main function, to invoke pRF analysis:
-        pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest)
+        pyprf_opt_brute(objNspc.config, objNspc, lgcTest)
 
 
 if __name__ == "__main__":

--- a/pyprf_feature/analysis/pyprf_opt_ep.py
+++ b/pyprf_feature/analysis/pyprf_opt_ep.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""
+Entry point for pyprf_opt_brute
+"""
+
+import os
+import argparse
+from pyprf_feature.analysis.pyprf_opt_brute import pyprf_opt_brute
+from pyprf_feature import __version__
+
+# Get path of this file:
+strDir = os.path.dirname(os.path.abspath(__file__))
+
+
+def get_arg_parse():
+    """"Parses the Command Line Arguments using argparse."""
+    # Create parser object:
+    objParser = argparse.ArgumentParser()
+
+    # Add argument to namespace - config file path:
+    objParser.add_argument('-config',
+                           metavar='/path/to/config.csv', required=True,
+                           help='Absolute file path of config file with \
+                                 parameters for pRF analysis. Ignored if in \
+                                 testing mode.'
+                           )
+
+    # Add argument to namespace - prior results file path:
+    objParser.add_argument('-strPthPrior',
+                           metavar='/path/to/my_prior_res', required=True,
+                           help='Absolute file path of prior pRF results. \
+                                 Ignored if in testing mode.'
+                           )
+
+    # Add argument to namespace - varNumOpt flag:
+    objParser.add_argument('-varNumOpt', type=int,
+                           metavar='N', required=True,
+                           help='Number of radial positions.'
+                           )
+
+    # Namespace object containign arguments and values:
+    objNspc = objParser.parse_args()
+
+    return objNspc
+
+
+def main():
+    """pyprf_opt_brute entry point."""
+    # Get list of input arguments (without first one, which is the path to the
+    # function that is called):  --NOTE: This is another way of accessing
+    # input arguments, but since we use 'argparse' it is redundant.
+    # lstArgs = sys.argv[1:]
+    strWelcome = 'pyprf_opt_brute ' + __version__
+    strDec = '=' * len(strWelcome)
+    print(strDec + '\n' + strWelcome + '\n' + strDec)
+
+    objNspc = get_arg_parse()
+
+    # Get path of config file from argument parser:
+    strCsvCnfg = objNspc.config
+    strPthPrior = objNspc.strPthPrior
+    varNumOpt = objNspc.varNumOpt
+
+    # Print info if no config argument is provided.
+    if any(item is None for item in [strCsvCnfg, strPthPrior, varNumOpt]):
+        print('Please provide the necessary input arguments, i.e.:')
+        print('   -strCsvCnfg -strPthPrior and -varNumOpt')
+
+    else:
+
+        # Signal non-test mode to lower functions (needed for pytest):
+        lgcTest = False
+
+        # Call to main function, to invoke pRF analysis:
+        pyprf_opt_brute(strCsvCnfg, objNspc, lgcTest)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyprf_feature/analysis/pyprf_opt_ep.py
+++ b/pyprf_feature/analysis/pyprf_opt_ep.py
@@ -17,7 +17,7 @@ def get_arg_parse():
     # Create parser object:
     objParser = argparse.ArgumentParser()
 
-    # Add argument to namespace - config file path:
+    # Add argument to namespace -config file path:
     objParser.add_argument('-config', required=True,
                            metavar='/path/to/config.csv',
                            help='Absolute file path of config file with \
@@ -25,36 +25,35 @@ def get_arg_parse():
                                  testing mode.'
                            )
 
-    # Add argument to namespace - prior results file path:
+    # Add argument to namespace -prior results file path:
     objParser.add_argument('-strPthPrior', required=True,
                            metavar='/path/to/my_prior_res',
                            help='Absolute file path of prior pRF results. \
                                  Ignored if in testing mode.'
                            )
 
-    # Add argument to namespace - varNumOpt1 flag:
+    # Add argument to namespace -varNumOpt1 flag:
     objParser.add_argument('-varNumOpt1', required=True, type=int,
                            metavar='N1',
                            help='Number of radial positions.'
                            )
 
-    # Add argument to namespace - varNumOpt2 flag:
+    # Add argument to namespace -varNumOpt2 flag:
     objParser.add_argument('-varNumOpt2', required=True, type=int,
                            metavar='N2',
                            help='Number of angular positions.'
                            )
 
-    # Add argument to namespace - varNumOpt3 flag:
+    # Add argument to namespace -varNumOpt3 flag:
     objParser.add_argument('-varNumOpt3', required=True, type=float,
                            metavar='N3',
                            help='Max displacement in radial direction.'
                            )
 
-    # Add argument to namespace - varNumOpt3 flag:
-    objParser.add_argument('-lgcRstrCentre', required=False, type=bool,
-                           metavar='lgcRstrCentre', default=True,
-                           help='Restrict models to stimaluted area.'
-                           )
+    # Add argument to namespace -lgcRstrCentre flag:
+    objParser.add_argument('-lgcRstrCentre', dest='lgcRstrCentre',
+                           action='store_true', default=False,
+                           help='Restrict fitted models to stimulated area.')
 
     # Namespace object containign arguments and values:
     objNspc = objParser.parse_args()

--- a/pyprf_feature/analysis/pyprf_opt_ep.py
+++ b/pyprf_feature/analysis/pyprf_opt_ep.py
@@ -18,29 +18,29 @@ def get_arg_parse():
     objParser = argparse.ArgumentParser()
 
     # Add argument to namespace - config file path:
-    objParser.add_argument('-config',
-                           metavar='/path/to/config.csv', required=True,
+    objParser.add_argument('-config', required=True,
+                           metavar='/path/to/config.csv',
                            help='Absolute file path of config file with \
                                  parameters for pRF analysis. Ignored if in \
                                  testing mode.'
                            )
 
     # Add argument to namespace - prior results file path:
-    objParser.add_argument('-strPthPrior',
-                           metavar='/path/to/my_prior_res', required=True,
+    objParser.add_argument('-strPthPrior', required=True,
+                           metavar='/path/to/my_prior_res',
                            help='Absolute file path of prior pRF results. \
                                  Ignored if in testing mode.'
                            )
 
     # Add argument to namespace - varNumOpt1 flag:
-    objParser.add_argument('-varNumOpt1', type=int,
-                           metavar='N', required=True,
+    objParser.add_argument('-varNumOpt1', required=True, type=int,
+                           metavar='N1',
                            help='Number of radial positions.'
                            )
 
     # Add argument to namespace - varNumOpt2 flag:
-    objParser.add_argument('-varNumOpt2', type=int,
-                           metavar='N', required=True,
+    objParser.add_argument('-varNumOpt2', required=True, type=int,
+                           metavar='N2',
                            help='Number of angular positions.'
                            )
 

--- a/pyprf_feature/analysis/save_fit_tc_nii.py
+++ b/pyprf_feature/analysis/save_fit_tc_nii.py
@@ -16,7 +16,7 @@ from pyprf_feature.analysis.model_creation_main import model_creation
 
 # %% Set configuration (csv) file that was used for the fitting
 
-strCsvCnfg = '/media/sf_D_DRIVE/MotDepPrf/Analysis/S02/04_motDepPrf/pRF_results/Average/S02_config_motDepPrf_expn_smooth_otw.csv'
+strCsvCnfg = '/home/marian/Documents/Testing/pyprf_feature_devel/S02_config_motDepPrf_flck_smooth_lowCnt.csv'
 
 # %% Load configuration settings that were used for fitting
 
@@ -41,7 +41,7 @@ aryBetas = load_res_prm(lstPathBeta, lstFlsMsk=[cfg.strPathNiiMask])[0][0]
 # Some voxels were excluded because they did not have sufficient mean
 # and/or variance - exclude their initial parameters, too
 # Get inclusion mask and nii header
-aryLgcMsk, aryLgcVar, hdrMsk, aryAff, _, tplNiiShp = prep_func(
+aryLgcMsk, aryLgcVar, hdrMsk, aryAff, aryFunc, tplNiiShp = prep_func(
     cfg.strPathNiiMask, cfg.lstPathNiiFunc)
 # Apply inclusion mask
 aryIntGssPrm = aryIntGssPrm[aryLgcVar, :]
@@ -102,10 +102,23 @@ for indRow, vecPrm in enumerate(aryUnqRows):
 errMsg = 'At least one voxel visited more than once for SStot calc'
 assert len(vecVxlTst) == np.sum(vecVxlTst), errMsg
 
+# %% Export preprocessed voxel time courses
+
+# List with name suffices of output images:
+lstNiiNames = ['_EmpTc']
+
+# Create full path names from nii file names and output path
+lstNiiNames = [cfg.strPathOut + strNii + '.nii.gz' for strNii in
+               lstNiiNames]
+
+# export beta parameter as a single 4D nii file
+export_nii(aryFunc, lstNiiNames, aryLgcMsk, aryLgcVar, tplNiiShp,
+           aryAff, hdrMsk, outFormat='4D')
+
 # %% Export fitted time courses as nii
 
 # List with name suffices of output images:
-lstNiiNames = ['_FittedTc']
+lstNiiNames = ['_FitTc']
 
 # Create full path names from nii file names and output path
 lstNiiNames = [cfg.strPathOut + strNii + '.nii.gz' for strNii in

--- a/pyprf_feature/analysis/save_fit_tc_nii.py
+++ b/pyprf_feature/analysis/save_fit_tc_nii.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Sep 13 17:34:37 2018
+
+@author: marian
+"""
+import numpy as np
+from pyprf_feature.analysis.load_config import load_config
+from pyprf_feature.analysis.utils_general import (cls_set_config, export_nii,
+                                                  load_res_prm)
+from pyprf_feature.analysis.prepare import prep_func, prep_models
+from pyprf_feature.analysis.model_creation_utils import (crt_mdl_prms,
+                                                         fnd_unq_rws)
+from pyprf_feature.analysis.model_creation_main import model_creation
+
+# %% Set configuration (csv) file that was used for the fitting
+
+strCsvCnfg = '/media/sf_D_DRIVE/MotDepPrf/Analysis/S02/04_motDepPrf/pRF_results/Average/S02_config_motDepPrf_expn_smooth_otw.csv'
+
+# %% Load configuration settings that were used for fitting
+
+# Load config parameters from csv file into dictionary:
+dicCnfg = load_config(strCsvCnfg, lgcTest=False)
+
+# Load config parameters from dictionary into namespace:
+cfg = cls_set_config(dicCnfg)
+
+# %% Load previous pRF fitting results
+
+# Load the x, y, sigma winner parameters from pyprf_feature
+lstWnrPrm = [cfg.strPathOut + '_x_pos.nii.gz',
+             cfg.strPathOut + '_y_pos.nii.gz',
+             cfg.strPathOut + '_SD.nii.gz']
+aryIntGssPrm = load_res_prm(lstWnrPrm, lstFlsMsk=[cfg.strPathNiiMask])[0][0]
+
+# Load beta parameters estimates, aka weights for time courses
+lstPathBeta = [cfg.strPathOut + '_Betas.nii.gz']
+aryBetas = load_res_prm(lstPathBeta, lstFlsMsk=[cfg.strPathNiiMask])[0][0]
+
+# Some voxels were excluded because they did not have sufficient mean
+# and/or variance - exclude their initial parameters, too
+# Get inclusion mask and nii header
+aryLgcMsk, aryLgcVar, hdrMsk, aryAff, _, tplNiiShp = prep_func(
+    cfg.strPathNiiMask, cfg.lstPathNiiFunc)
+# Apply inclusion mask
+aryIntGssPrm = aryIntGssPrm[aryLgcVar, :]
+aryBetas = aryBetas[aryLgcVar, :]
+
+# Get array with model parameters that were fitted on a grid
+# [x positions, y positions, sigmas]
+aryMdlParams = crt_mdl_prms((int(cfg.varVslSpcSzeX),
+                            int(cfg.varVslSpcSzeY)), cfg.varNum1,
+                            cfg.varExtXmin, cfg.varExtXmax, cfg.varNum2,
+                            cfg.varExtYmin, cfg.varExtYmax,
+                            cfg.varNumPrfSizes, cfg.varPrfStdMin,
+                            cfg.varPrfStdMax, kwUnt='deg',
+                            kwCrd=cfg.strKwCrd)
+# Get corresponding pRF model time courses
+aryPrfTc = np.load(cfg.strPathMdl + '.npy')
+
+# The model time courses will be preprocessed such that they are smoothed
+# (temporally) with same factor as the data and that they will be z-scored:
+aryPrfTc = prep_models(aryPrfTc, varSdSmthTmp=cfg.varSdSmthTmp)
+
+# %% Derive fitted time course models for all voxels
+
+# Initialize array that will collect the fitted time courses
+aryFitTc = np.zeros((aryIntGssPrm.shape[0],
+                     aryPrfTc.shape[-1]), dtype=np.float32)
+# create vector that allows to check whether every voxel is visited
+# exactly once
+vecVxlTst = np.zeros(aryIntGssPrm.shape[0])
+
+# Find unique rows of fitted model parameters
+aryUnqRows, aryUnqInd = fnd_unq_rws(aryIntGssPrm, return_index=False,
+                                    return_inverse=True)
+
+# Loop over all best-fitting model parameter combinations found
+for indRow, vecPrm in enumerate(aryUnqRows):
+    # Get logical for voxels for which this prm combi was the best
+    lgcVxl = [aryUnqInd == indRow][0]
+    if np.all(np.invert(lgcVxl)):
+        print('---No voxel found')
+    # Get logical index for the model number
+    # This can only be 1 index, so we directly get 1st entry of array
+    lgcMdl = np.where(np.isclose(aryMdlParams, vecPrm,
+                                 atol=1e-04).all(axis=1))[0][0]
+    if lgcMdl is None:
+        print('---No model found')
+    # Mark those voxels that were visited
+    vecVxlTst[lgcVxl] += 1
+
+    # Get model time courses
+    aryMdlTc = aryPrfTc[lgcMdl, :, :]
+    # Get beta parameter estimates
+    aryWeights = aryBetas[lgcVxl, :]
+    # Combine model time courses and weights
+    aryFitTc[lgcVxl, :] = np.dot(aryWeights, aryMdlTc)
+
+# check that every voxel was visited exactly once
+errMsg = 'At least one voxel visited more than once for SStot calc'
+assert len(vecVxlTst) == np.sum(vecVxlTst), errMsg
+
+# %% Export fitted time courses as nii
+
+# List with name suffices of output images:
+lstNiiNames = ['_FittedTc']
+
+# Create full path names from nii file names and output path
+lstNiiNames = [cfg.strPathOut + strNii + '.nii.gz' for strNii in
+               lstNiiNames]
+
+# export beta parameter as a single 4D nii file
+export_nii(aryFitTc, lstNiiNames, aryLgcMsk, aryLgcVar, tplNiiShp,
+           aryAff, hdrMsk, outFormat='4D')

--- a/pyprf_feature/analysis/utils_general.py
+++ b/pyprf_feature/analysis/utils_general.py
@@ -357,6 +357,30 @@ def map_pol_to_crt(aryTht, aryRad):
     return aryXCrds, aryYrds
 
 
+def find_near_pol_ang(aryEmpPlrAng, aryExpPlrAng):
+    """Return index of nearest expected polar angle.
+
+    Parameters
+    ----------
+    aryEmpPlrAng : 1D numpy array
+        Empirically found polar angle estimates
+    aryExpPlrAng : 1D numpy array
+        Theoretically expected polar angle estimates
+
+    Returns
+    -------
+    aryXCrds : 1D numpy array
+        Indices of nearest theoretically expected polar angle.
+    aryYrds : 1D numpy array
+        Distances to nearest theoretically expected polar angle.
+    """
+
+    dist = np.abs(np.subtract(aryEmpPlrAng[:, None],
+                              aryExpPlrAng[None, :]))
+
+    return np.argmin(dist, axis=-1), np.min(dist, axis=-1)
+
+
 def rmp_rng(aryVls, varNewMin, varNewMax, varOldThrMin=None,
             varOldAbsMax=None):
     """Remap values in an array from one range to another.

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,6 @@ setup(name='pyprf_feature',
       entry_points={
           'console_scripts': [
               'pyprf_feature = pyprf_feature.analysis.__main__:main',
+              'pyprf_opt_brute = pyprf_feature.analysis.pyprf_opt_ep:main',
               ]},
       )


### PR DESCRIPTION
* Added capability to brute-force optimize in a range around pRF parameters that were found in prior data. This can be called with a new entry_point pyprf_brute_opt.
* Added script to derive fitted time courses to compare directly with empirical time courses.
* Exclude voxels with NaN values during preprocesing.
* Type of nii file is set explicitly to float 32 (before type was copied from mask.nii file).